### PR TITLE
Add support for React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,33 @@ This functionality is available in various file types commonly used in React dev
 
 - #### This also works with async snippets.
 
+## Component Generation
+
+You can easily generate a React Component snippet by typing `fc.ComponentName` for functional components
+OR `cc.ComponentName` for class components and pressing Enter. The extension automatically expands this into a properly formatted React Component.
+
+For example, typing `fc.ComponentName` and pressing Enter will generate:
+
+```javascript
+const ComponentName = () => {
+  return (
+    <div></div>
+  );
+};
+```
+
+## Component props support
+
+- For example: `fc.ComponentName[firstName, lastName]` will create:
+
+  ```javascript
+  const ComponentName = ({firstName, lastName}) => {
+    return (
+      <div></div>
+    );
+  };
+  ```
+
 ### Planned Features
 
 In future updates, we plan to extend support to other React hooks, such as `useContext`, and more, following the same intuitive Emmet-like pattern for quick and efficient coding.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       {
         "command": "extension.generateReactHookSnippet",
         "title": "Generate React Hook"
+      },
+      {
+        "command": "extension.generateReactComponentSnippet",
+        "title": "Generate React Component"
       }
     ],
     "keybindings": [
@@ -37,6 +41,11 @@
         "command": "extension.generateReactHookSnippet",
         "key": "enter",
         "when": "editorTextFocus && !editorReadonly && editorLangId =~ /javascript|typescript|javascriptreact|typescriptreact/ && isReactHookPattern"
+      },
+      {
+        "command": "extension.generateReactComponentSnippet",
+        "key": "enter",
+        "when": "editorTextFocus && !editorReadonly && editorLangId =~ /javascript|typescript|javascriptreact|typescriptreact/ && isReactComponentPattern"
       }
     ]
   },


### PR DESCRIPTION
related: #3

It's just an initial effort to give a baseline of the described feature :)


```
cc.ComponentNam
class ComponentName extends React.Component {
  render() {
    return (
      <div></div>
    );
  }
}

cc.ComponentName[name]
class ComponentName extends React.Component {
  render() {
    return (
      <div></div>
    );
  }
}

fc.ComponentName
const ComponentName = () => {
  return (
    <div></div>
  );
};

fc.ComponentName[firstName, lastName]
const ComponentName = ({firstName, lastName}) => {
  return (
    <div></div>
  );
};
```